### PR TITLE
File double/single click logic update

### DIFF
--- a/fdialog.py
+++ b/fdialog.py
@@ -433,15 +433,10 @@ class FileDialog:
                     elif os.path.isfile(user_data[1]):
                         if not len(self.selected_files) > 1:
                             self.selected_files.append(user_data[1])
-                            #If double click on a file
-                            if (current_time - self.last_click_time < 0.5) and (self.last_clicked_element == sender): 
-                                return_items()
-                            return user_data[1]
-                        else:
-                            #If double click on a file
-                            if (current_time - self.last_click_time < 0.5) and (self.last_clicked_element == sender):
-                                return_items()
-                            return user_data[1]
+                        #If double click on a file
+                        if (current_time - self.last_click_time < 0.5) and (self.last_clicked_element == sender): 
+                            return_items()
+                        return user_data[1]
                 self.last_click_time = current_time
                 self.last_clicked_element = sender
 

--- a/fdialog.py
+++ b/fdialog.py
@@ -433,12 +433,13 @@ class FileDialog:
                     elif os.path.isfile(user_data[1]):
                         if not len(self.selected_files) > 1:
                             self.selected_files.append(user_data[1])
-                        #If double click on a file
+                        #Check if two click within 0.5s proximity
                         if (current_time - self.last_click_time < 0.5) and (self.last_clicked_element == sender): 
                             return_items()
+                        else:
+                            self.last_click_time = current_time
+                            self.last_clicked_element = sender
                         return user_data[1]
-                self.last_click_time = current_time
-                self.last_clicked_element = sender
 
         def _search():
             res = dpg.get_value("ex_search")

--- a/fdialog.py
+++ b/fdialog.py
@@ -426,20 +426,22 @@ class FileDialog:
                 dpg.set_value(sender, True)
 
                 current_time = time.time()
-                if (current_time - self.last_click_time < 0.5) and (self.last_clicked_element == sender):
-                    if user_data is not None and user_data[1] is not None:
-                        if os.path.isdir(user_data[1]):
-                            # print(f"Content:{dpg.get_item_label(sender)}, files: {user_data}")
-                            chdir(user_data[1])
-                            dpg.set_value("ex_search", "")
-                        elif os.path.isfile(user_data[1]):
-                            if not len(self.selected_files) > 1:
-                                self.selected_files.append(user_data[1])
+                if user_data is not None and user_data[1] is not None:
+                    if os.path.isdir(user_data[1]):
+                        chdir(user_data[1])
+                        dpg.set_value("ex_search", "")
+                    elif os.path.isfile(user_data[1]):
+                        if not len(self.selected_files) > 1:
+                            self.selected_files.append(user_data[1])
+                            #If double click on a file
+                            if (current_time - self.last_click_time < 0.5) and (self.last_clicked_element == sender): 
                                 return_items()
-                                return user_data[1]
-                            else:
+                            return user_data[1]
+                        else:
+                            #If double click on a file
+                            if (current_time - self.last_click_time < 0.5) and (self.last_clicked_element == sender):
                                 return_items()
-                                return user_data[1]
+                            return user_data[1]
                 self.last_click_time = current_time
                 self.last_clicked_element = sender
 


### PR DESCRIPTION
Can only select single file by double clicking, while doing single click and pressing  "ok" button will not work, this can be tested with the example.py file.
This pull request fix it, by calling return_items() only after checking for double click condition, if user select file by single click it will not call return_items().