### PR TITLE
Class function refactoring + Making inner tagging system unique + Allowing folder selection

### DIFF
--- a/fdialog.py
+++ b/fdialog.py
@@ -207,82 +207,75 @@ class FileDialog:
 
         # high-level
         with dpg.texture_registry():
-            try:
-                dpg.add_static_texture(
-                    width=self.ico_document[0], height=self.ico_document[1], default_value=self.ico_document[2], tag=self.tag+"ico_document")
-                dpg.add_static_texture(
-                    width=self.ico_home[0], height=self.ico_home[1], default_value=self.ico_home[2], tag=self.tag+"ico_home")
-                dpg.add_static_texture(
-                    width=self.ico_add_folder[0], height=self.ico_add_folder[1], default_value=self.ico_add_folder[2], tag=self.tag+"ico_add_folder")
-                dpg.add_static_texture(
-                    width=self.ico_add_file[0], height=self.ico_add_file[1], default_value=self.ico_add_file[2], tag=self.tag+"ico_add_file")
-                dpg.add_static_texture(
-                    width=self.ico_mini_folder[0], height=self.ico_mini_folder[1], default_value=self.ico_mini_folder[2], tag=self.tag+"ico_mini_folder")
-                dpg.add_static_texture(
-                    width=self.ico_folder[0], height=self.ico_folder[1], default_value=self.ico_folder[2], tag=self.tag+"ico_folder")
-                dpg.add_static_texture(width=self.ico_mini_document[0], height=self.ico_mini_document[1],
-                                       default_value=self.ico_mini_document[2], tag=self.tag+"ico_mini_document")
-                dpg.add_static_texture(
-                    width=self.ico_mini_error[0], height=self.ico_mini_error[1], default_value=self.ico_mini_error[2], tag=self.tag+"ico_mini_error")
-                dpg.add_static_texture(
-                    width=self.ico_refresh[0], height=self.ico_refresh[1], default_value=self.ico_refresh[2], tag=self.tag+"ico_refresh")
-                dpg.add_static_texture(
-                    width=self.ico_hard_disk[0], height=self.ico_hard_disk[1], default_value=self.ico_hard_disk[2], tag=self.tag+"ico_hard_disk")
-                dpg.add_static_texture(
-                    width=self.ico_picture[0], height=self.ico_picture[1], default_value=self.ico_picture[2], tag=self.tag+"ico_picture")
-                dpg.add_static_texture(
-                    width=self.ico_big_picture[0], height=self.ico_big_picture[1], default_value=self.ico_big_picture[2], tag=self.tag+"ico_big_picture")
-                dpg.add_static_texture(width=self.ico_picture_folder[0], height=self.ico_picture_folder[1],
-                                       default_value=self.ico_picture_folder[2], tag=self.tag+"ico_picture_folder")
-                dpg.add_static_texture(
-                    width=self.ico_desktop[0], height=self.ico_desktop[1], default_value=self.ico_desktop[2], tag=self.tag+"ico_desktop")
-                dpg.add_static_texture(
-                    width=self.ico_videos[0], height=self.ico_videos[1], default_value=self.ico_videos[2], tag=self.tag+"ico_videos")
-                dpg.add_static_texture(
-                    width=self.ico_music_folder[0], height=self.ico_music_folder[1], default_value=self.ico_music_folder[2], tag=self.tag+"ico_music_folder")
-                dpg.add_static_texture(
-                    width=self.ico_downloads[0], height=self.ico_downloads[1], default_value=self.ico_downloads[2], tag=self.tag+"ico_downloads")
-                dpg.add_static_texture(width=self.ico_document_folder[0], height=self.ico_document_folder[1],
-                                       default_value=self.ico_document_folder[2], tag=self.tag+"ico_document_folder")
-                dpg.add_static_texture(
-                    width=self.ico_search[0], height=self.ico_search[1], default_value=self.ico_search[2], tag=self.tag+"ico_search")
-                dpg.add_static_texture(
-                    width=self.ico_back[0], height=self.ico_back[1], default_value=self.ico_back[2], tag=self.tag+"ico_back")
-                dpg.add_static_texture(
-                    width=self.ico_c[0], height=self.ico_c[1], default_value=self.ico_c[2], tag=self.tag+"ico_c")
-                dpg.add_static_texture(
-                    width=self.ico_gears[0], height=self.ico_gears[1], default_value=self.ico_gears[2], tag=self.tag+"ico_gears")
-                dpg.add_static_texture(
-                    width=self.ico_music_note[0], height=self.ico_music_note[1], default_value=self.ico_music_note[2], tag=self.tag+"ico_music_note")
-                dpg.add_static_texture(
-                    width=self.ico_note[0], height=self.ico_note[1], default_value=self.ico_note[2], tag=self.tag+"ico_note")
-                dpg.add_static_texture(
-                    width=self.ico_object[0], height=self.ico_object[1], default_value=self.ico_object[2], tag=self.tag+"ico_object")
-                dpg.add_static_texture(
-                    width=self.ico_python[0], height=self.ico_python[1], default_value=self.ico_python[2], tag=self.tag+"ico_python")
-                dpg.add_static_texture(
-                    width=self.ico_script[0], height=self.ico_script[1], default_value=self.ico_script[2], tag=self.tag+"ico_script")
-                dpg.add_static_texture(
-                    width=self.ico_video[0], height=self.ico_video[1], default_value=self.ico_video[2], tag=self.tag+"ico_video")
-                dpg.add_static_texture(
-                    width=self.ico_link[0], height=self.ico_link[1], default_value=self.ico_link[2], tag=self.tag+"ico_link")
-                dpg.add_static_texture(
-                    width=self.ico_url[0], height=self.ico_url[1], default_value=self.ico_url[2], tag=self.tag+"ico_url")
-                dpg.add_static_texture(
-                    width=self.ico_vector[0], height=self.ico_vector[1], default_value=self.ico_vector[2], tag=self.tag+"ico_vector")
-                dpg.add_static_texture(
-                    width=self.ico_zip[0], height=self.ico_zip[1], default_value=self.ico_zip[2], tag=self.tag+"ico_zip")
-                dpg.add_static_texture(
-                    width=self.ico_app[0], height=self.ico_app[1], default_value=self.ico_app[2], tag=self.tag+"ico_app")
-                dpg.add_static_texture(
-                    width=self.ico_iso[0], height=self.ico_iso[1], default_value=self.ico_iso[2], tag=self.tag+"ico_iso")
-            except SystemError as e:
-                msg = str(e)
-                if "<built-in function add_static_texture> returned a result with an exception set" in msg:
-                    print("Ignoring duplicate alias error.")
-                else:
-                    raise
-
+            dpg.add_static_texture(
+                width=self.ico_document[0], height=self.ico_document[1], default_value=self.ico_document[2], tag=self.tag+"ico_document")
+            dpg.add_static_texture(
+                width=self.ico_home[0], height=self.ico_home[1], default_value=self.ico_home[2], tag=self.tag+"ico_home")
+            dpg.add_static_texture(
+                width=self.ico_add_folder[0], height=self.ico_add_folder[1], default_value=self.ico_add_folder[2], tag=self.tag+"ico_add_folder")
+            dpg.add_static_texture(
+                width=self.ico_add_file[0], height=self.ico_add_file[1], default_value=self.ico_add_file[2], tag=self.tag+"ico_add_file")
+            dpg.add_static_texture(
+                width=self.ico_mini_folder[0], height=self.ico_mini_folder[1], default_value=self.ico_mini_folder[2], tag=self.tag+"ico_mini_folder")
+            dpg.add_static_texture(
+                width=self.ico_folder[0], height=self.ico_folder[1], default_value=self.ico_folder[2], tag=self.tag+"ico_folder")
+            dpg.add_static_texture(width=self.ico_mini_document[0], height=self.ico_mini_document[1],
+                                   default_value=self.ico_mini_document[2], tag=self.tag+"ico_mini_document")
+            dpg.add_static_texture(
+                width=self.ico_mini_error[0], height=self.ico_mini_error[1], default_value=self.ico_mini_error[2], tag=self.tag+"ico_mini_error")
+            dpg.add_static_texture(
+                width=self.ico_refresh[0], height=self.ico_refresh[1], default_value=self.ico_refresh[2], tag=self.tag+"ico_refresh")
+            dpg.add_static_texture(
+                width=self.ico_hard_disk[0], height=self.ico_hard_disk[1], default_value=self.ico_hard_disk[2], tag=self.tag+"ico_hard_disk")
+            dpg.add_static_texture(
+                width=self.ico_picture[0], height=self.ico_picture[1], default_value=self.ico_picture[2], tag=self.tag+"ico_picture")
+            dpg.add_static_texture(
+                width=self.ico_big_picture[0], height=self.ico_big_picture[1], default_value=self.ico_big_picture[2], tag=self.tag+"ico_big_picture")
+            dpg.add_static_texture(width=self.ico_picture_folder[0], height=self.ico_picture_folder[1],
+                                   default_value=self.ico_picture_folder[2], tag=self.tag+"ico_picture_folder")
+            dpg.add_static_texture(
+                width=self.ico_desktop[0], height=self.ico_desktop[1], default_value=self.ico_desktop[2], tag=self.tag+"ico_desktop")
+            dpg.add_static_texture(
+                width=self.ico_videos[0], height=self.ico_videos[1], default_value=self.ico_videos[2], tag=self.tag+"ico_videos")
+            dpg.add_static_texture(
+                width=self.ico_music_folder[0], height=self.ico_music_folder[1], default_value=self.ico_music_folder[2], tag=self.tag+"ico_music_folder")
+            dpg.add_static_texture(
+                width=self.ico_downloads[0], height=self.ico_downloads[1], default_value=self.ico_downloads[2], tag=self.tag+"ico_downloads")
+            dpg.add_static_texture(width=self.ico_document_folder[0], height=self.ico_document_folder[1],
+                                   default_value=self.ico_document_folder[2], tag=self.tag+"ico_document_folder")
+            dpg.add_static_texture(
+                width=self.ico_search[0], height=self.ico_search[1], default_value=self.ico_search[2], tag=self.tag+"ico_search")
+            dpg.add_static_texture(
+                width=self.ico_back[0], height=self.ico_back[1], default_value=self.ico_back[2], tag=self.tag+"ico_back")
+            dpg.add_static_texture(
+                width=self.ico_c[0], height=self.ico_c[1], default_value=self.ico_c[2], tag=self.tag+"ico_c")
+            dpg.add_static_texture(
+                width=self.ico_gears[0], height=self.ico_gears[1], default_value=self.ico_gears[2], tag=self.tag+"ico_gears")
+            dpg.add_static_texture(
+                width=self.ico_music_note[0], height=self.ico_music_note[1], default_value=self.ico_music_note[2], tag=self.tag+"ico_music_note")
+            dpg.add_static_texture(
+                width=self.ico_note[0], height=self.ico_note[1], default_value=self.ico_note[2], tag=self.tag+"ico_note")
+            dpg.add_static_texture(
+                width=self.ico_object[0], height=self.ico_object[1], default_value=self.ico_object[2], tag=self.tag+"ico_object")
+            dpg.add_static_texture(
+                width=self.ico_python[0], height=self.ico_python[1], default_value=self.ico_python[2], tag=self.tag+"ico_python")
+            dpg.add_static_texture(
+                width=self.ico_script[0], height=self.ico_script[1], default_value=self.ico_script[2], tag=self.tag+"ico_script")
+            dpg.add_static_texture(
+                width=self.ico_video[0], height=self.ico_video[1], default_value=self.ico_video[2], tag=self.tag+"ico_video")
+            dpg.add_static_texture(
+                width=self.ico_link[0], height=self.ico_link[1], default_value=self.ico_link[2], tag=self.tag+"ico_link")
+            dpg.add_static_texture(
+                width=self.ico_url[0], height=self.ico_url[1], default_value=self.ico_url[2], tag=self.tag+"ico_url")
+            dpg.add_static_texture(
+                width=self.ico_vector[0], height=self.ico_vector[1], default_value=self.ico_vector[2], tag=self.tag+"ico_vector")
+            dpg.add_static_texture(
+                width=self.ico_zip[0], height=self.ico_zip[1], default_value=self.ico_zip[2], tag=self.tag+"ico_zip")
+            dpg.add_static_texture(
+                width=self.ico_app[0], height=self.ico_app[1], default_value=self.ico_app[2], tag=self.tag+"ico_app")
+            dpg.add_static_texture(
+                width=self.ico_iso[0], height=self.ico_iso[1], default_value=self.ico_iso[2], tag=self.tag+"ico_iso")
+            
             self.img_document= self.tag + "ico_document"
             self.img_home= self.tag + "ico_home"
             self.img_add_folder= self.tag + "ico_add_folder"
@@ -756,7 +749,7 @@ class FileDialog:
                 reset_dir(os.getcwd(), witem="date", order=user_data[0][1])
             elif (thingforsort == 3): # size
                 reset_dir(os.getcwd(), witem="size", order=user_data[0][1])
- """
+         """
 
         # main file dialog header
         with dpg.window(label="File dialog", tag=self.tag, no_resize=self.no_resize, show=False, modal=self.modal, width=self.width, height=self.height, min_size=self.min_size, no_collapse=True, pos=(50, 50)):

--- a/fdialog.py
+++ b/fdialog.py
@@ -167,7 +167,7 @@ class FileDialog:
 
     def _search(self):
         res = dpg.get_value(self.tag+"ex_search")
-        reset_dir(default_path=os.getcwd(), file_name_filter=res)
+        self.reset_dir(default_path=os.getcwd(), file_name_filter=res)
 
     def get_directory_path(self, directory_name):
         try:
@@ -451,20 +451,23 @@ class FileDialog:
                             if not self._is_hidden(file):
                                 if file_name_filter:
                                     if dpg.get_value(self.tag+"ex_search") in file:
-                                        _makefile(file, self.open_file)
+                                        self._makefile(file, self.open_file)
                                 else:
-                                    _makefile(file, self.open_file)
+                                    self._makefile(file, self.open_file)
                             elif self._is_hidden(file) and self.show_hidden_files:
                                 if file_name_filter:
                                     if dpg.get_value(self.tag+"ex_search") in file:
-                                        _makefile(file, self.open_file)
+                                        self._makefile(file, self.open_file)
                                 else:
-                                    _makefile(file, self.open_file)
+                                    self._makefile(file, self.open_file)
 
             # exceptions
             except FileNotFoundError:
                 print("DEV:ERROR: Invalid path : "+str(default_path))
             except Exception as e:
+                #Catch all exception, so should at least print it out
+                import traceback
+                traceback.print_exception (type (e), e, e.__traceback__)
                 self.message_box(
                     "File dialog - Error", f"An unknown error has occured when listing the items, More info:\n{e}")
 

--- a/fdialog.py
+++ b/fdialog.py
@@ -207,110 +207,116 @@ class FileDialog:
 
         # high-level
         with dpg.texture_registry():
-            dpg.add_static_texture(
-                width=self.ico_document[0], height=self.ico_document[1], default_value=self.ico_document[2], tag="ico_document")
-            dpg.add_static_texture(
-                width=self.ico_home[0], height=self.ico_home[1], default_value=self.ico_home[2], tag="ico_home")
-            dpg.add_static_texture(
-                width=self.ico_add_folder[0], height=self.ico_add_folder[1], default_value=self.ico_add_folder[2], tag="ico_add_folder")
-            dpg.add_static_texture(
-                width=self.ico_add_file[0], height=self.ico_add_file[1], default_value=self.ico_add_file[2], tag="ico_add_file")
-            dpg.add_static_texture(
-                width=self.ico_mini_folder[0], height=self.ico_mini_folder[1], default_value=self.ico_mini_folder[2], tag="ico_mini_folder")
-            dpg.add_static_texture(
-                width=self.ico_folder[0], height=self.ico_folder[1], default_value=self.ico_folder[2], tag="ico_folder")
-            dpg.add_static_texture(width=self.ico_mini_document[0], height=self.ico_mini_document[1],
-                                   default_value=self.ico_mini_document[2], tag="ico_mini_document")
-            dpg.add_static_texture(
-                width=self.ico_mini_error[0], height=self.ico_mini_error[1], default_value=self.ico_mini_error[2], tag="ico_mini_error")
-            dpg.add_static_texture(
-                width=self.ico_refresh[0], height=self.ico_refresh[1], default_value=self.ico_refresh[2], tag="ico_refresh")
-            dpg.add_static_texture(
-                width=self.ico_hard_disk[0], height=self.ico_hard_disk[1], default_value=self.ico_hard_disk[2], tag="ico_hard_disk")
-            dpg.add_static_texture(
-                width=self.ico_picture[0], height=self.ico_picture[1], default_value=self.ico_picture[2], tag="ico_picture")
-            dpg.add_static_texture(
-                width=self.ico_big_picture[0], height=self.ico_big_picture[1], default_value=self.ico_big_picture[2], tag="ico_big_picture")
-            dpg.add_static_texture(width=self.ico_picture_folder[0], height=self.ico_picture_folder[1],
-                                   default_value=self.ico_picture_folder[2], tag="ico_picture_folder")
-            dpg.add_static_texture(
-                width=self.ico_desktop[0], height=self.ico_desktop[1], default_value=self.ico_desktop[2], tag="ico_desktop")
-            dpg.add_static_texture(
-                width=self.ico_videos[0], height=self.ico_videos[1], default_value=self.ico_videos[2], tag="ico_videos")
-            dpg.add_static_texture(
-                width=self.ico_music_folder[0], height=self.ico_music_folder[1], default_value=self.ico_music_folder[2], tag="ico_music_folder")
-            dpg.add_static_texture(
-                width=self.ico_downloads[0], height=self.ico_downloads[1], default_value=self.ico_downloads[2], tag="ico_downloads")
-            dpg.add_static_texture(width=self.ico_document_folder[0], height=self.ico_document_folder[1],
-                                   default_value=self.ico_document_folder[2], tag="ico_document_folder")
-            dpg.add_static_texture(
-                width=self.ico_search[0], height=self.ico_search[1], default_value=self.ico_search[2], tag="ico_search")
-            dpg.add_static_texture(
-                width=self.ico_back[0], height=self.ico_back[1], default_value=self.ico_back[2], tag="ico_back")
-            dpg.add_static_texture(
-                width=self.ico_c[0], height=self.ico_c[1], default_value=self.ico_c[2], tag="ico_c")
-            dpg.add_static_texture(
-                width=self.ico_gears[0], height=self.ico_gears[1], default_value=self.ico_gears[2], tag="ico_gears")
-            dpg.add_static_texture(
-                width=self.ico_music_note[0], height=self.ico_music_note[1], default_value=self.ico_music_note[2], tag="ico_music_note")
-            dpg.add_static_texture(
-                width=self.ico_note[0], height=self.ico_note[1], default_value=self.ico_note[2], tag="ico_note")
-            dpg.add_static_texture(
-                width=self.ico_object[0], height=self.ico_object[1], default_value=self.ico_object[2], tag="ico_object")
-            dpg.add_static_texture(
-                width=self.ico_python[0], height=self.ico_python[1], default_value=self.ico_python[2], tag="ico_python")
-            dpg.add_static_texture(
-                width=self.ico_script[0], height=self.ico_script[1], default_value=self.ico_script[2], tag="ico_script")
-            dpg.add_static_texture(
-                width=self.ico_video[0], height=self.ico_video[1], default_value=self.ico_video[2], tag="ico_video")
-            dpg.add_static_texture(
-                width=self.ico_link[0], height=self.ico_link[1], default_value=self.ico_link[2], tag="ico_link")
-            dpg.add_static_texture(
-                width=self.ico_url[0], height=self.ico_url[1], default_value=self.ico_url[2], tag="ico_url")
-            dpg.add_static_texture(
-                width=self.ico_vector[0], height=self.ico_vector[1], default_value=self.ico_vector[2], tag="ico_vector")
-            dpg.add_static_texture(
-                width=self.ico_zip[0], height=self.ico_zip[1], default_value=self.ico_zip[2], tag="ico_zip")
-            dpg.add_static_texture(
-                width=self.ico_app[0], height=self.ico_app[1], default_value=self.ico_app[2], tag="ico_app")
-            dpg.add_static_texture(
-                width=self.ico_iso[0], height=self.ico_iso[1], default_value=self.ico_iso[2], tag="ico_iso")
+            try:
+                dpg.add_static_texture(
+                    width=self.ico_document[0], height=self.ico_document[1], default_value=self.ico_document[2], tag=self.tag+"ico_document")
+                dpg.add_static_texture(
+                    width=self.ico_home[0], height=self.ico_home[1], default_value=self.ico_home[2], tag=self.tag+"ico_home")
+                dpg.add_static_texture(
+                    width=self.ico_add_folder[0], height=self.ico_add_folder[1], default_value=self.ico_add_folder[2], tag=self.tag+"ico_add_folder")
+                dpg.add_static_texture(
+                    width=self.ico_add_file[0], height=self.ico_add_file[1], default_value=self.ico_add_file[2], tag=self.tag+"ico_add_file")
+                dpg.add_static_texture(
+                    width=self.ico_mini_folder[0], height=self.ico_mini_folder[1], default_value=self.ico_mini_folder[2], tag=self.tag+"ico_mini_folder")
+                dpg.add_static_texture(
+                    width=self.ico_folder[0], height=self.ico_folder[1], default_value=self.ico_folder[2], tag=self.tag+"ico_folder")
+                dpg.add_static_texture(width=self.ico_mini_document[0], height=self.ico_mini_document[1],
+                                       default_value=self.ico_mini_document[2], tag=self.tag+"ico_mini_document")
+                dpg.add_static_texture(
+                    width=self.ico_mini_error[0], height=self.ico_mini_error[1], default_value=self.ico_mini_error[2], tag=self.tag+"ico_mini_error")
+                dpg.add_static_texture(
+                    width=self.ico_refresh[0], height=self.ico_refresh[1], default_value=self.ico_refresh[2], tag=self.tag+"ico_refresh")
+                dpg.add_static_texture(
+                    width=self.ico_hard_disk[0], height=self.ico_hard_disk[1], default_value=self.ico_hard_disk[2], tag=self.tag+"ico_hard_disk")
+                dpg.add_static_texture(
+                    width=self.ico_picture[0], height=self.ico_picture[1], default_value=self.ico_picture[2], tag=self.tag+"ico_picture")
+                dpg.add_static_texture(
+                    width=self.ico_big_picture[0], height=self.ico_big_picture[1], default_value=self.ico_big_picture[2], tag=self.tag+"ico_big_picture")
+                dpg.add_static_texture(width=self.ico_picture_folder[0], height=self.ico_picture_folder[1],
+                                       default_value=self.ico_picture_folder[2], tag=self.tag+"ico_picture_folder")
+                dpg.add_static_texture(
+                    width=self.ico_desktop[0], height=self.ico_desktop[1], default_value=self.ico_desktop[2], tag=self.tag+"ico_desktop")
+                dpg.add_static_texture(
+                    width=self.ico_videos[0], height=self.ico_videos[1], default_value=self.ico_videos[2], tag=self.tag+"ico_videos")
+                dpg.add_static_texture(
+                    width=self.ico_music_folder[0], height=self.ico_music_folder[1], default_value=self.ico_music_folder[2], tag=self.tag+"ico_music_folder")
+                dpg.add_static_texture(
+                    width=self.ico_downloads[0], height=self.ico_downloads[1], default_value=self.ico_downloads[2], tag=self.tag+"ico_downloads")
+                dpg.add_static_texture(width=self.ico_document_folder[0], height=self.ico_document_folder[1],
+                                       default_value=self.ico_document_folder[2], tag=self.tag+"ico_document_folder")
+                dpg.add_static_texture(
+                    width=self.ico_search[0], height=self.ico_search[1], default_value=self.ico_search[2], tag=self.tag+"ico_search")
+                dpg.add_static_texture(
+                    width=self.ico_back[0], height=self.ico_back[1], default_value=self.ico_back[2], tag=self.tag+"ico_back")
+                dpg.add_static_texture(
+                    width=self.ico_c[0], height=self.ico_c[1], default_value=self.ico_c[2], tag=self.tag+"ico_c")
+                dpg.add_static_texture(
+                    width=self.ico_gears[0], height=self.ico_gears[1], default_value=self.ico_gears[2], tag=self.tag+"ico_gears")
+                dpg.add_static_texture(
+                    width=self.ico_music_note[0], height=self.ico_music_note[1], default_value=self.ico_music_note[2], tag=self.tag+"ico_music_note")
+                dpg.add_static_texture(
+                    width=self.ico_note[0], height=self.ico_note[1], default_value=self.ico_note[2], tag=self.tag+"ico_note")
+                dpg.add_static_texture(
+                    width=self.ico_object[0], height=self.ico_object[1], default_value=self.ico_object[2], tag=self.tag+"ico_object")
+                dpg.add_static_texture(
+                    width=self.ico_python[0], height=self.ico_python[1], default_value=self.ico_python[2], tag=self.tag+"ico_python")
+                dpg.add_static_texture(
+                    width=self.ico_script[0], height=self.ico_script[1], default_value=self.ico_script[2], tag=self.tag+"ico_script")
+                dpg.add_static_texture(
+                    width=self.ico_video[0], height=self.ico_video[1], default_value=self.ico_video[2], tag=self.tag+"ico_video")
+                dpg.add_static_texture(
+                    width=self.ico_link[0], height=self.ico_link[1], default_value=self.ico_link[2], tag=self.tag+"ico_link")
+                dpg.add_static_texture(
+                    width=self.ico_url[0], height=self.ico_url[1], default_value=self.ico_url[2], tag=self.tag+"ico_url")
+                dpg.add_static_texture(
+                    width=self.ico_vector[0], height=self.ico_vector[1], default_value=self.ico_vector[2], tag=self.tag+"ico_vector")
+                dpg.add_static_texture(
+                    width=self.ico_zip[0], height=self.ico_zip[1], default_value=self.ico_zip[2], tag=self.tag+"ico_zip")
+                dpg.add_static_texture(
+                    width=self.ico_app[0], height=self.ico_app[1], default_value=self.ico_app[2], tag=self.tag+"ico_app")
+                dpg.add_static_texture(
+                    width=self.ico_iso[0], height=self.ico_iso[1], default_value=self.ico_iso[2], tag=self.tag+"ico_iso")
+            except SystemError as e:
+                msg = str(e)
+                if "<built-in function add_static_texture> returned a result with an exception set" in msg:
+                    print("Ignoring duplicate alias error.")
+                else:
+                    raise
 
-            self.img_document = "ico_document"
-            self.img_home = "ico_home"
-            self.img_add_folder = "ico_add_folder"
-            self.img_add_file = "ico_add_file"
-            self.img_mini_folder = "ico_mini_folder"
-            self.img_folder = "ico_folder"
-            self.img_mini_document = "ico_mini_document"
-            self.img_mini_error = "ico_mini_error"
-            self.img_refresh = "ico_refresh"
-            self.img_hard_disk = "ico_hard_disk"
-            self.img_picture = "ico_picture"
-            self.img_big_picture = "ico_big_picture"
-            self.img_picture_folder = "ico_picture_folder"
-            self.img_desktop = "ico_desktop"
-            self.img_videos = "ico_videos"
-            self.img_music_folder = "ico_music_folder"
-            self.img_downloads = "ico_downloads"
-            self.img_document_folder = "ico_document_folder"
-            self.img_search = "ico_search"
-            self.img_back = "ico_back"
-            self.img_c = "ico_c"
-            self.img_gears = "ico_gears"
-            self.img_music_note = "ico_music_note"
-            self.img_note = "ico_note"
-            self.img_object = "ico_object"
-            self.img_python = "ico_python"
-            self.img_script = "ico_script"
-            self.img_video = "ico_video"
-            self.img_link = "ico_link"
-            self.img_url = "ico_url"
-            self.img_vector = "ico_vector"
-            self.img_zip = "ico_zip"
-            self.img_app = "ico_app"
-            self.img_iso = "ico_iso"
-
+            self.img_document= self.tag + "ico_document"
+            self.img_home= self.tag + "ico_home"
+            self.img_add_folder= self.tag + "ico_add_folder"
+            self.img_add_file= self.tag + "ico_add_file"
+            self.img_mini_folder= self.tag + "ico_mini_folder"
+            self.img_folder= self.tag + "ico_folder"
+            self.img_mini_document= self.tag + "ico_mini_document"
+            self.img_mini_error= self.tag + "ico_mini_error"
+            self.img_refresh= self.tag + "ico_refresh"
+            self.img_hard_disk= self.tag + "ico_hard_disk"
+            self.img_picture= self.tag + "ico_picture"
+            self.img_big_picture= self.tag + "ico_big_picture"
+            self.img_picture_folder= self.tag + "ico_picture_folder"
+            self.img_desktop= self.tag + "ico_desktop"
+            self.img_videos= self.tag + "ico_videos"
+            self.img_music_folder= self.tag + "ico_music_folder"
+            self.img_downloads= self.tag + "ico_downloads"
+            self.img_document_folder= self.tag + "ico_document_folder"
+            self.img_search= self.tag + "ico_search"
+            self.img_back= self.tag + "ico_back"
+            self.img_c= self.tag + "ico_c"
+            self.img_gears= self.tag + "ico_gears"
+            self.img_music_note= self.tag + "ico_music_note"
+            self.img_note= self.tag + "ico_note"
+            self.img_object= self.tag + "ico_object"
+            self.img_python= self.tag + "ico_python"
+            self.img_script= self.tag + "ico_script"
+            self.img_video= self.tag + "ico_video"
+            self.img_link = self.tag+"ico_link"
+            self.img_url = self.tag+"ico_url"
+            self.img_vector = self.tag+"ico_vector"
+            self.img_zip = self.tag+"ico_zip"
+            self.img_app = self.tag+"ico_app"
+            self.img_iso = self.tag+"ico_iso"
         # low-level functions
 
         def _get_all_drives():
@@ -329,7 +335,7 @@ class FileDialog:
             return drive_list
 
         def delete_table():
-            for child in dpg.get_item_children("explorer", 1):
+            for child in dpg.get_item_children(self.tag+"explorer", 1):
                 dpg.delete_item(child)
 
         def get_file_size(file_path):
@@ -373,7 +379,7 @@ class FileDialog:
 
         def on_path_enter():
             try:
-                chdir(dpg.get_value("ex_path_input"))
+                chdir(dpg.get_value(self.tag+"ex_path_input"))
             except FileNotFoundError:
                 message_box("Invalid path", "No such file or directory")
 
@@ -429,7 +435,7 @@ class FileDialog:
                 if user_data is not None and user_data[1] is not None:
                     if os.path.isdir(user_data[1]):
                         chdir(user_data[1])
-                        dpg.set_value("ex_search", "")
+                        dpg.set_value(self.tag+"ex_search", "")
                     elif os.path.isfile(user_data[1]):
                         if not len(self.selected_files) > 1:
                             self.selected_files.append(user_data[1])
@@ -442,7 +448,7 @@ class FileDialog:
                         return user_data[1]
 
         def _search():
-            res = dpg.get_value("ex_search")
+            res = dpg.get_value(self.tag+"ex_search")
             reset_dir(default_path=os.getcwd(), file_name_filter=res)
 
         def get_directory_path(directory_name):
@@ -495,7 +501,7 @@ class FileDialog:
             except:
                 return False
 
-        def _makedir(item, callback, parent="explorer", size=False):
+        def _makedir(item, callback, parent=self.tag + "explorer", size=False):
             file_name = os.path.basename(item)
 
             creation_time = os.path.getctime(item)
@@ -547,7 +553,7 @@ class FileDialog:
                     elif item_type == "File":
                         dpg.add_image(self.img_document, parent=drag_payload)
 
-        def _makefile(item, callback, parent="explorer"):
+        def _makefile(item, callback, parent=self.tag+"explorer"):
             if self.file_filter == ".*" or item.endswith(self.file_filter):
                 file_name = os.path.basename(item)
 
@@ -561,7 +567,6 @@ class FileDialog:
                     file_name, os.path.join(os.getcwd(), file_name)]}
                 kwargs_file = {'tint_color': [
                     255, 255, 255, self.image_transparency]}
-
                 with dpg.table_row(parent=parent):
                     with dpg.group(horizontal=True):
 
@@ -659,7 +664,7 @@ class FileDialog:
                 dpg.set_value(sender, False)
                 current_time = time.time()
                 if current_time - self.last_click_time < 0.5 and self.last_clicked_element == sender:
-                    dpg.set_value("ex_search", "")
+                    dpg.set_value(self.tag+"ex_search", "")
                     chdir("..")
                     self.last_click_time = 0
                 self.last_click_time = current_time
@@ -688,7 +693,7 @@ class FileDialog:
                 self.selected_files.clear()
                 try:
                     dpg.configure_item(
-                        "ex_path_input", default_value=os.getcwd())
+                        self.tag+"ex_path_input", default_value=os.getcwd())
                     _dir = os.listdir(default_path)
                     delete_table()
 
@@ -697,7 +702,7 @@ class FileDialog:
                     files = [file for file in _dir if os.path.isfile(file)]
 
                     # 'special directory' that sends back to the prevorius directory
-                    with dpg.table_row(parent="explorer"):
+                    with dpg.table_row(parent=self.tag+"explorer"):
                         dpg.add_selectable(
                             label="..", callback=_back, span_columns=True, height=self.selec_height)
 
@@ -705,13 +710,13 @@ class FileDialog:
                         for _dir in dirs:
                             if not _is_hidden(_dir):
                                 if file_name_filter:
-                                    if dpg.get_value("ex_search") in _dir:
+                                    if dpg.get_value(self.tag+"ex_search") in _dir:
                                         _makedir(_dir, open_file)
                                 else:
                                     _makedir(_dir, open_file)
                             elif _is_hidden(_dir) and self.show_hidden_files:
                                 if file_name_filter:
-                                    if dpg.get_value("ex_search") in _dir:
+                                    if dpg.get_value(self.tag+"ex_search") in _dir:
                                         _makedir(_dir, open_file)
                                 else:
                                     _makedir(_dir, open_file)
@@ -721,13 +726,13 @@ class FileDialog:
                             for file in files:
                                 if not _is_hidden(file):
                                     if file_name_filter:
-                                        if dpg.get_value("ex_search") in file:
+                                        if dpg.get_value(self.tag+"ex_search") in file:
                                             _makefile(file, open_file)
                                     else:
                                         _makefile(file, open_file)
                                 elif _is_hidden(file) and self.show_hidden_files:
                                     if file_name_filter:
-                                        if dpg.get_value("ex_search") in file:
+                                        if dpg.get_value(self.tag+"ex_search") in file:
                                             _makefile(file, open_file)
                                     else:
                                         _makefile(file, open_file)
@@ -738,6 +743,7 @@ class FileDialog:
                 except Exception as e:
                     message_box(
                         "File dialog - Error", f"An unknown error has occured when listing the items, More info:\n{e}")
+                    raise e
 
             internal()
 
@@ -760,7 +766,7 @@ class FileDialog:
             with dpg.group(horizontal=True):
                 # shortcut menu
                 if (self.user_style == 0):
-                    with dpg.child_window(tag="shortcut_menu", width=200, resizable_x=True, show=self.show_shortcuts_menu, height=-info_px):
+                    with dpg.child_window(tag=self.tag+"shortcut_menu", width=200, resizable_x=True, show=self.show_shortcuts_menu, height=-info_px):
                         home = get_directory_path("Home")
                         desktop = get_directory_path("Desktop")
                         downloads = get_directory_path("Downloads")
@@ -810,7 +816,7 @@ class FileDialog:
                                         label=drive, user_data=drive, callback=open_drive)
 
                 elif (self.user_style == 1):
-                    with dpg.child_window(tag="shortcut_menu", width=40, show=self.show_shortcuts_menu, height=-info_px):
+                    with dpg.child_window(tag=self.tag+"shortcut_menu", width=40, show=self.show_shortcuts_menu, height=-info_px):
                         home = get_directory_path("Home")
                         desktop = get_directory_path("Desktop")
                         downloads = get_directory_path("Downloads")
@@ -852,15 +858,15 @@ class FileDialog:
                             dpg.add_image_button(
                                 self.img_back, callback=lambda: chdir(self.default_path))
                             dpg.add_input_text(hint="Path", on_enter=True, callback=on_path_enter,  default_value=os.getcwd(
-                            ), width=-1, tag="ex_path_input")
+                            ), width=-1, tag=self.tag+"ex_path_input")
 
                         with dpg.group(horizontal=True):
                             dpg.add_input_text(
-                                hint="Search files", callback=_search, tag="ex_search", width=-1)
+                                hint="Search files", callback=_search, tag=self.tag+"ex_search", width=-1)
 
                         # main explorer table header
                         with dpg.table(
-                            tag='explorer',
+                            tag=self.tag+"explorer",
                             height=-1,
                             width=-1,
                             resizable=True,
@@ -877,13 +883,13 @@ class FileDialog:
                             iwow_type = 10
                             iwow_size = 10
                             dpg.add_table_column(
-                                label='Name',     init_width_or_weight=iwow_name, tag="ex_name")
+                                label='Name',     init_width_or_weight=iwow_name, tag=self.tag+"ex_name")
                             dpg.add_table_column(
-                                label='Date',     init_width_or_weight=iwow_date, tag="ex_date")
+                                label='Date',     init_width_or_weight=iwow_date, tag=self.tag+"ex_date")
                             dpg.add_table_column(
-                                label='Type',     init_width_or_weight=iwow_type, tag="ex_type")
+                                label='Type',     init_width_or_weight=iwow_type, tag=self.tag+"ex_type")
                             dpg.add_table_column(
-                                label='Size',     init_width_or_weight=iwow_size, width=10, tag="ex_size")
+                                label='Size',     init_width_or_weight=iwow_size, width=10, tag=self.tag+"ex_size")
 
             with dpg.group(horizontal=True):
                 dpg.add_spacer(width=480)

--- a/fdialog.py
+++ b/fdialog.py
@@ -33,7 +33,442 @@ class FileDialog:
     Returns:
         None
     """
+    # low-level functions
+    def _get_all_drives(self,):
+        all_drives = psutil.disk_partitions()
 
+        drive_list = [
+            drive.mountpoint for drive in all_drives if drive.mountpoint]
+
+        if os.name == 'posix':
+            for device in os.listdir('/dev'):
+                if device.startswith("sd") or device.startswith("nvme"):
+                    device_path = f"/dev/{device}"
+                    if device_path not in drive_list:
+                        drive_list.append(device_path)
+
+        return drive_list
+
+    def delete_table(self,):
+        for child in dpg.get_item_children(self.tag+"explorer", 1):
+            dpg.delete_item(child)
+
+    def get_file_size(self, file_path):
+        # Get the file size in bytes
+
+        if os.path.isdir(file_path):
+            if self.show_dir_size:
+                total = 0
+                for path, dirs, files in os.walk(file_path):
+                    for f in files:
+                        fp = os.path.join(path, f)
+                        total += os.path.getsize(fp)
+                file_size_bytes = total
+            else:
+                file_size_bytes = "-"
+        elif os.path.isfile(file_path):
+            file_size_bytes = os.path.getsize(file_path)
+
+        # Define the units and their respective sizes
+        size_units = [
+            ("TB", 2**40),  # Terabyte
+            ("GB", 2**30),  # Gigabyte
+            ("MB", 2**20),  # Megabyte
+            ("KB", 2**10),  # Kilobyte
+            ("B", 1),       # Byte
+        ]
+
+        # Determine the appropriate unit for formatting
+        if not file_size_bytes == "-":
+            for unit, size_limit in size_units:
+                if file_size_bytes >= size_limit:
+                    # Calculate the size in the selected unit
+                    file_size = file_size_bytes / size_limit
+                    # Return the formatted size with the unit
+                    return f"{file_size:.0f} {unit}"
+        else:
+            return "-"
+
+        # If the file size is smaller than 1 byte or unknown
+        return "0 B"  # or "Unknown" or any other desired default
+
+    def on_path_enter(self, ):
+        try:
+            self.chdir(dpg.get_value(self.tag+"ex_path_input"))
+        except FileNotFoundError:
+            self.message_box("Invalid path", "No such file or directory")
+
+    def message_box(self, title, message):
+        if not self.modal:
+            with dpg.mutex():
+                viewport_width = dpg.get_viewport_client_width()
+                viewport_height = dpg.get_viewport_client_height()
+                with dpg.window(label=title, no_close=True, modal=True) as modal_id:
+                    dpg.add_text(message)
+                    with dpg.group(horizontal=True):
+                        dpg.add_button(label="Ok", width=-1, user_data=(modal_id,
+                                       True), callback=lambda: dpg.delete_item(modal_id))
+
+            dpg.split_frame()
+            width = dpg.get_item_width(modal_id)
+            height = dpg.get_item_height(modal_id)
+            dpg.set_item_pos(
+                modal_id, [viewport_width // 2 - width // 2, viewport_height // 2 - height // 2])
+        else:
+            print(
+                f"DEV:ERROR:{title}:\t{message}\n\t\t\tCannot display message while file_dialog is in modal")
+
+    def return_items(self):
+        dpg.hide_item(self.tag)
+        if self.callback is None:
+            pass
+        else:
+            self.callback(self.selected_files)
+        self.selected_files.clear()
+        reset_dir(default_path=self.default_path)
+
+    def open_drive(self, sender, app_data, user_data):
+        self.chdir(user_data)
+
+    def open_file(self, sender, app_data, user_data):
+        # Multi selection, Allow only when multi_select is picked
+        if dpg.is_key_down(dpg.mvKey_LControl) or dpg.is_key_down(dpg.mvKey_RControl):
+            if self.multi_selection:
+                if dpg.get_value(sender) is True:
+                    self.selected_files.append(user_data[1])
+                else:
+                    self.selected_files.remove(user_data[1])
+        # Single selection
+        else:
+            if len(self.selected_files) > 0:
+                self.selected_files.clear()
+                if self.last_clicked_element is not None:
+                    dpg.set_value(self.last_clicked_element, False)
+            dpg.set_value(sender, True)
+
+            current_time = time.time()
+            if user_data is not None and user_data[1] is not None:
+                if os.path.isdir(user_data[1]):
+                    self.chdir(user_data[1])
+                    self.last_clicked_element = None #Dir changed, so reset this variable
+                    dpg.set_value(self.tag+"ex_search", "")
+                    if (self.dirs_only == True): #If dirs_only == True, we now allow user to select directory then press "OK"
+                        self.selected_files = [user_data[1]]
+                elif os.path.isfile(user_data[1]):
+                    if not len(self.selected_files) > 1:
+                        self.selected_files.append(user_data[1])
+                    #Check if two click within 0.5s proximity
+                    if (current_time - self.last_click_time < 0.5) and (self.last_clicked_element == sender): 
+                        return_items()
+                    else:
+                        self.last_click_time = current_time
+                        self.last_clicked_element = sender
+                    return user_data[1]
+
+    def _search(self):
+        res = dpg.get_value(self.tag+"ex_search")
+        reset_dir(default_path=os.getcwd(), file_name_filter=res)
+
+    def get_directory_path(self, directory_name):
+        try:
+            # Check for Linux or MacOS
+            if platform.system() in ["Linux", "Darwin"] and directory_name.lower() == "home":
+                directory_path = os.path.expanduser("~")
+            # Check for Windows
+            elif platform.system() == "Windows" and directory_name.lower() == "home":
+                directory_path = os.path.expanduser("~")
+            else:
+                # Attempt to join the home directory with the specified directory name
+                directory_path = os.path.join(
+                    os.path.expanduser("~"), directory_name)
+
+            # Verify if the directory exists
+            os.listdir(directory_path)  # Test access
+        except FileNotFoundError:
+            # Search for the directory in the user's home folder
+            search_path = os.path.expanduser("~/*/" + directory_name)
+            directory_path = glob.glob(search_path)
+            if directory_path:
+                try:
+                    # Test access to the found path
+                    os.listdir(directory_path[0])
+                    # Use the found path
+                    directory_path = directory_path[0]
+                except FileNotFoundError:
+                    message_box("File dialog - Error",
+                                "Could not find the selected directory")
+                    return "."
+            else:
+                message_box("File dialog - Error",
+                            "Could not find the selected directory")
+                return "."
+
+        return directory_path
+
+    def _is_hidden(self, filepath):
+        name = os.path.basename(os.path.abspath(filepath))
+        return name.startswith('.') or (os.name == 'nt' and self._has_hidden_attribute(filepath))
+
+    def _has_hidden_attribute(self, filepath):
+        try:
+            import ctypes
+            FILE_ATTRIBUTE_HIDDEN = 0x2
+            attrs = ctypes.windll.kernel32.GetFileAttributesW(
+                str(filepath))
+            return FILE_ATTRIBUTE_HIDDEN & attrs
+        except:
+            return False
+
+    def _makedir(self, item, callback, parent=None, size=False):
+        if parent is None:
+            parent = self.tag + "explorer"
+        file_name = os.path.basename(item)
+
+        creation_time = os.path.getctime(item)
+        creation_time = time.ctime(creation_time)
+
+        item_type = "Dir"
+
+        item_size = self.get_file_size(item)
+
+        kwargs_cell = {'callback': callback, 'span_columns': True, 'height': self.selec_height, 'user_data': [
+            file_name, os.path.join(os.getcwd(), file_name)]}
+        kwargs_file = {'tint_color': [255, 255, 255, 255]}
+        with dpg.table_row(parent=parent):
+            with dpg.group(horizontal=True):
+                if item_type == "Dir":
+
+                    if self._is_hidden(file_name):
+                        kwargs_file = {'tint_color': [
+                            255, 255, 255, self.image_transparency]}
+                    else:
+
+                        kwargs_file = {'tint_color': [255, 255, 255, 255]}
+
+                    dpg.add_image(self.img_mini_folder, **kwargs_file)
+                elif item_type == "File":
+                    dpg.add_image(self.img_mini_document, **kwargs_file)
+
+                cell_name = dpg.add_selectable(
+                    label=file_name, **kwargs_cell)
+            cell_time = dpg.add_selectable(
+                label=creation_time, **kwargs_cell)
+            cell_type = dpg.add_selectable(label=item_type, **kwargs_cell)
+            cell_size = dpg.add_selectable(
+                label=str(item_size), **kwargs_cell)
+
+            if self.allow_drag is True:
+                drag_payload = dpg.add_drag_payload(
+                    parent=cell_name, payload_type=self.PAYLOAD_TYPE)
+            dpg.bind_item_theme(cell_name, self.selec_alignt)
+            dpg.bind_item_theme(cell_time, self.selec_alignt)
+            dpg.bind_item_theme(cell_type, self.selec_alignt)
+            dpg.bind_item_theme(cell_size, self.size_alignt)
+            if self.allow_drag is True:
+                if file_name.endswith((".png", ".jpg")):
+                    dpg.add_image(self.img_big_picture,
+                                  parent=drag_payload)
+                elif item_type == "Dir":
+                    dpg.add_image(self.img_folder, parent=drag_payload)
+                elif item_type == "File":
+                    dpg.add_image(self.img_document, parent=drag_payload)
+
+    def _makefile(self, item, callback, parent=None):
+        if parent is None:
+            parent = self.tag+"explorer"
+        if self.file_filter == ".*" or item.endswith(self.file_filter):
+            file_name = os.path.basename(item)
+
+            creation_time = os.path.getctime(item)
+            creation_time = time.ctime(creation_time)
+
+            item_type = "File"
+
+            item_size = self.get_file_size(item)
+            kwargs_cell = {'callback': callback, 'span_columns': True, 'height': self.selec_height, 'user_data': [
+                file_name, os.path.join(os.getcwd(), file_name)]}
+            kwargs_file = {'tint_color': [
+                255, 255, 255, self.image_transparency]}
+            with dpg.table_row(parent=parent):
+                with dpg.group(horizontal=True):
+
+                    if item_type == "Dir":
+                        dpg.add_image(self.img_mini_folder, **kwargs_file)
+                    elif item_type == "File":
+
+                        if self._is_hidden(file_name):
+                            kwargs_file = {'tint_color': [
+                                255, 255, 255, self.image_transparency]}
+                        else:
+                            kwargs_file = {
+                                'tint_color': [255, 255, 255, 255]}
+
+                        if file_name.endswith((".dll", ".a", ".o", ".so", ".ko")):
+                            dpg.add_image(self.img_gears, **kwargs_file)
+
+                        elif file_name.endswith((".png", ".jpg", ".jpeg")):
+                            dpg.add_image(self.img_picture, **kwargs_file)
+
+                        elif file_name.endswith((".msi", ".exe", ".bat", ".bin", ".elf")):
+                            dpg.add_image(self.img_app, **kwargs_file)
+
+                        elif file_name.endswith(".iso"):
+                            dpg.add_image(self.img_iso, **kwargs_file)
+
+                        elif file_name.endswith((".zip", ".deb", ".rpm", ".tar.gz", ".tar", ".gz", ".lzo", ".lz4", ".7z", ".ppack")):
+                            dpg.add_image(self.img_zip, **kwargs_file)
+
+                        elif file_name.endswith((".png", ".jpg", ".jpeg")):
+                            dpg.add_image(self.img_picture, **kwargs_file)
+
+                        elif file_name.endswith((".py", ".pyo", ".pyw", ".pyi", ".pyc", ".pyz", ".pyd")):
+                            dpg.add_image(self.img_python, **kwargs_file)
+
+                        elif file_name.endswith(".c"):
+                            dpg.add_image(self.img_c, **kwargs_file)
+                        elif file_name.endswith((".js", ".json", ".cs", ".cpp", ".h", ".hpp", ".sh", ".pyl", ".rs", ".vbs", ".cmd")):
+                            dpg.add_image(self.img_script, **kwargs_file)
+
+                        elif file_name.endswith(".url"):
+                            dpg.add_image(self.img_url, **kwargs_file)
+                        elif file_name.endswith(".lnk"):
+                            dpg.add_image(self.img_link, **kwargs_file)
+
+                        elif file_name.endswith(".txt"):
+                            dpg.add_image(self.img_note, **kwargs_file)
+                        elif file_name.endswith((".mp3", ".ogg", ".wav")):
+                            dpg.add_image(
+                                self.img_music_note, **kwargs_file)
+
+                        elif file_name.endswith((".mp4", ".mov")):
+                            dpg.add_image(self.img_video, **kwargs_file)
+
+                        elif file_name.endswith((".obj", ".fbx", ".blend")):
+                            dpg.add_image(self.img_object, **kwargs_file)
+
+                        elif file_name.endswith(".svg"):
+                            dpg.add_image(self.img_vector, **kwargs_file)
+
+                        else:
+                            dpg.add_image(
+                                self.img_mini_document, **kwargs_file)
+
+                    cell_name = dpg.add_selectable(
+                        label=file_name, **kwargs_cell)
+                cell_time = dpg.add_selectable(
+                    label=creation_time, **kwargs_cell)
+                cell_type = dpg.add_selectable(
+                    label=item_type, **kwargs_cell)
+                cell_size = dpg.add_selectable(
+                    label=str(item_size), **kwargs_cell)
+
+                if self.allow_drag is True:
+                    drag_payload = dpg.add_drag_payload(
+                        parent=cell_name, payload_type=self.PAYLOAD_TYPE)
+                dpg.bind_item_theme(cell_name, self.selec_alignt)
+                dpg.bind_item_theme(cell_time, self.selec_alignt)
+                dpg.bind_item_theme(cell_type, self.selec_alignt)
+                dpg.bind_item_theme(cell_size, self.size_alignt)
+                if self.allow_drag is True:
+                    if file_name.endswith((".png", ".jpg")):
+                        dpg.add_image(self.img_big_picture,
+                                      parent=drag_payload)
+                    elif item_type == "Dir":
+                        dpg.add_image(self.img_folder, parent=drag_payload)
+                    elif item_type == "File":
+                        dpg.add_image(self.img_document,
+                                      parent=drag_payload)
+
+    def _back(self, sender, app_data, user_data):
+        if dpg.is_key_down(dpg.mvKey_LControl) or dpg.is_key_down(dpg.mvKey_RControl):
+            dpg.set_value(sender, False)
+        else:
+            dpg.set_value(sender, False)
+            current_time = time.time()
+            if current_time - self.last_click_time < 0.5 and self.last_clicked_element == sender:
+                dpg.set_value(self.tag+"ex_search", "")
+                self.chdir("..")
+                self.last_click_time = 0
+            self.last_click_time = current_time
+            self.last_clicked_element = sender
+
+    def filter_combo_selector(self, sender, app_data):
+        filter_file = dpg.get_value(sender)
+        self.file_filter = filter_file
+        cwd = os.getcwd()
+        reset_dir(default_path=cwd)
+
+    def chdir(self, path):
+        try:
+            os.chdir(path)
+            cwd = os.getcwd()
+            self.reset_dir(default_path=cwd)
+        except PermissionError as e:
+            message_box("File dialog - PerimssionError",
+                        f"Cannot open the folder because is a system folder or the access is denied\n\nMore info:\n{e}")
+        except NotADirectoryError as e:
+            message_box("File dialog - not a directory",
+                        f"The selected item is not a directory, but a file.\n\nMore info:\n{e}")
+
+    def reset_dir(self, file_name_filter=None, default_path=None):
+        if default_path is None:
+            default_path = self.default_path
+        def internal():
+            self.selected_files.clear()
+            try:
+                dpg.configure_item(
+                    self.tag+"ex_path_input", default_value=os.getcwd())
+                _dir = os.listdir(default_path)
+                self.delete_table()
+
+                # Separate directories and files
+                dirs = [file for file in _dir if os.path.isdir(file)]
+                files = [file for file in _dir if os.path.isfile(file)]
+
+                # 'special directory' that sends back to the prevorius directory
+                with dpg.table_row(parent=self.tag+"explorer"):
+                    dpg.add_selectable(
+                        label="..", callback=self._back, span_columns=True, height=self.selec_height)
+
+                    # dir list
+                    for _dir in dirs:
+                        if not self._is_hidden(_dir):
+                            if file_name_filter:
+                                if dpg.get_value(self.tag+"ex_search") in _dir:
+                                    self._makedir(_dir, self.open_file)
+                            else:
+                                self._makedir(_dir, self.open_file)
+                        elif self._is_hidden(_dir) and self.show_hidden_files:
+                            if file_name_filter:
+                                if dpg.get_value(self.tag+"ex_search") in _dir:
+                                    self._makedir(_dir, self.open_file)
+                            else:
+                                self._makedir(_dir, self.open_file)
+
+                    # file list
+                    if not self.dirs_only:
+                        for file in files:
+                            if not self._is_hidden(file):
+                                if file_name_filter:
+                                    if dpg.get_value(self.tag+"ex_search") in file:
+                                        _makefile(file, self.open_file)
+                                else:
+                                    _makefile(file, self.open_file)
+                            elif self._is_hidden(file) and self.show_hidden_files:
+                                if file_name_filter:
+                                    if dpg.get_value(self.tag+"ex_search") in file:
+                                        _makefile(file, self.open_file)
+                                else:
+                                    _makefile(file, self.open_file)
+
+            # exceptions
+            except FileNotFoundError:
+                print("DEV:ERROR: Invalid path : "+str(default_path))
+            except Exception as e:
+                self.message_box(
+                    "File dialog - Error", f"An unknown error has occured when listing the items, More info:\n{e}")
+
+        internal()
     def __init__(
         self,
         title="File dialog",
@@ -56,7 +491,7 @@ class FileDialog:
         show_hidden_files=False,
         user_style=0
     ):
-        global chdir
+        #global self.chdir
 
         # args
         self.title = title
@@ -89,12 +524,12 @@ class FileDialog:
 
         # file dialog theme
 
-        with dpg.theme() as selec_alignt:
+        with dpg.theme() as self.selec_alignt:
             with dpg.theme_component(dpg.mvThemeCat_Core):
                 dpg.add_theme_style(
                     dpg.mvStyleVar_SelectableTextAlign, x=0, y=.5)
 
-        with dpg.theme() as size_alignt:
+        with dpg.theme() as self.size_alignt:
             with dpg.theme_component(dpg.mvThemeCat_Core):
                 dpg.add_theme_style(
                     dpg.mvStyleVar_SelectableTextAlign, x=1, y=.5)
@@ -310,436 +745,7 @@ class FileDialog:
             self.img_zip = self.tag+"ico_zip"
             self.img_app = self.tag+"ico_app"
             self.img_iso = self.tag+"ico_iso"
-        # low-level functions
-
-        def _get_all_drives():
-            all_drives = psutil.disk_partitions()
-
-            drive_list = [
-                drive.mountpoint for drive in all_drives if drive.mountpoint]
-
-            if os.name == 'posix':
-                for device in os.listdir('/dev'):
-                    if device.startswith("sd") or device.startswith("nvme"):
-                        device_path = f"/dev/{device}"
-                        if device_path not in drive_list:
-                            drive_list.append(device_path)
-
-            return drive_list
-
-        def delete_table():
-            for child in dpg.get_item_children(self.tag+"explorer", 1):
-                dpg.delete_item(child)
-
-        def get_file_size(file_path):
-            # Get the file size in bytes
-
-            if os.path.isdir(file_path):
-                if self.show_dir_size:
-                    total = 0
-                    for path, dirs, files in os.walk(file_path):
-                        for f in files:
-                            fp = os.path.join(path, f)
-                            total += os.path.getsize(fp)
-                    file_size_bytes = total
-                else:
-                    file_size_bytes = "-"
-            elif os.path.isfile(file_path):
-                file_size_bytes = os.path.getsize(file_path)
-
-            # Define the units and their respective sizes
-            size_units = [
-                ("TB", 2**40),  # Terabyte
-                ("GB", 2**30),  # Gigabyte
-                ("MB", 2**20),  # Megabyte
-                ("KB", 2**10),  # Kilobyte
-                ("B", 1),       # Byte
-            ]
-
-            # Determine the appropriate unit for formatting
-            if not file_size_bytes == "-":
-                for unit, size_limit in size_units:
-                    if file_size_bytes >= size_limit:
-                        # Calculate the size in the selected unit
-                        file_size = file_size_bytes / size_limit
-                        # Return the formatted size with the unit
-                        return f"{file_size:.0f} {unit}"
-            else:
-                return "-"
-
-            # If the file size is smaller than 1 byte or unknown
-            return "0 B"  # or "Unknown" or any other desired default
-
-        def on_path_enter():
-            try:
-                chdir(dpg.get_value(self.tag+"ex_path_input"))
-            except FileNotFoundError:
-                message_box("Invalid path", "No such file or directory")
-
-        def message_box(title, message):
-            if not self.modal:
-                with dpg.mutex():
-                    viewport_width = dpg.get_viewport_client_width()
-                    viewport_height = dpg.get_viewport_client_height()
-                    with dpg.window(label=title, no_close=True, modal=True) as modal_id:
-                        dpg.add_text(message)
-                        with dpg.group(horizontal=True):
-                            dpg.add_button(label="Ok", width=-1, user_data=(modal_id,
-                                           True), callback=lambda: dpg.delete_item(modal_id))
-
-                dpg.split_frame()
-                width = dpg.get_item_width(modal_id)
-                height = dpg.get_item_height(modal_id)
-                dpg.set_item_pos(
-                    modal_id, [viewport_width // 2 - width // 2, viewport_height // 2 - height // 2])
-            else:
-                print(
-                    f"DEV:ERROR:{title}:\t{message}\n\t\t\tCannot display message while file_dialog is in modal")
-
-        def return_items():
-            dpg.hide_item(self.tag)
-            if callback is None:
-                pass
-            else:
-                self.callback(self.selected_files)
-            self.selected_files.clear()
-            reset_dir(default_path=self.default_path)
-
-        def open_drive(sender, app_data, user_data):
-            chdir(user_data)
-
-        def open_file(sender, app_data, user_data):
-            # Multi selection, Allow only when multi_select is picked
-            if dpg.is_key_down(dpg.mvKey_LControl) or dpg.is_key_down(dpg.mvKey_RControl):
-                if self.multi_selection:
-                    if dpg.get_value(sender) is True:
-                        self.selected_files.append(user_data[1])
-                    else:
-                        self.selected_files.remove(user_data[1])
-            # Single selection
-            else:
-                if len(self.selected_files) > 0:
-                    self.selected_files.clear()
-                    if self.last_clicked_element is not None:
-                        dpg.set_value(self.last_clicked_element, False)
-                dpg.set_value(sender, True)
-
-                current_time = time.time()
-                if user_data is not None and user_data[1] is not None:
-                    if os.path.isdir(user_data[1]):
-                        chdir(user_data[1])
-                        dpg.set_value(self.tag+"ex_search", "")
-                        if (self.dirs_only == True): #If click once on directory and dirs_only == True
-                            self.selected_files = [user_data[1]]
-                    elif os.path.isfile(user_data[1]):
-                        if not len(self.selected_files) > 1:
-                            self.selected_files.append(user_data[1])
-                        #Check if two click within 0.5s proximity
-                        if (current_time - self.last_click_time < 0.5) and (self.last_clicked_element == sender): 
-                            return_items()
-                        else:
-                            self.last_click_time = current_time
-                            self.last_clicked_element = sender
-                        return user_data[1]
-
-        def _search():
-            res = dpg.get_value(self.tag+"ex_search")
-            reset_dir(default_path=os.getcwd(), file_name_filter=res)
-
-        def get_directory_path(directory_name):
-            try:
-                # Check for Linux or MacOS
-                if platform.system() in ["Linux", "Darwin"] and directory_name.lower() == "home":
-                    directory_path = os.path.expanduser("~")
-                # Check for Windows
-                elif platform.system() == "Windows" and directory_name.lower() == "home":
-                    directory_path = os.path.expanduser("~")
-                else:
-                    # Attempt to join the home directory with the specified directory name
-                    directory_path = os.path.join(
-                        os.path.expanduser("~"), directory_name)
-
-                # Verify if the directory exists
-                os.listdir(directory_path)  # Test access
-            except FileNotFoundError:
-                # Search for the directory in the user's home folder
-                search_path = os.path.expanduser("~/*/" + directory_name)
-                directory_path = glob.glob(search_path)
-                if directory_path:
-                    try:
-                        # Test access to the found path
-                        os.listdir(directory_path[0])
-                        # Use the found path
-                        directory_path = directory_path[0]
-                    except FileNotFoundError:
-                        message_box("File dialog - Error",
-                                    "Could not find the selected directory")
-                        return "."
-                else:
-                    message_box("File dialog - Error",
-                                "Could not find the selected directory")
-                    return "."
-
-            return directory_path
-
-        def _is_hidden(filepath):
-            name = os.path.basename(os.path.abspath(filepath))
-            return name.startswith('.') or (os.name == 'nt' and _has_hidden_attribute(filepath))
-
-        def _has_hidden_attribute(filepath):
-            try:
-                import ctypes
-                FILE_ATTRIBUTE_HIDDEN = 0x2
-                attrs = ctypes.windll.kernel32.GetFileAttributesW(
-                    str(filepath))
-                return FILE_ATTRIBUTE_HIDDEN & attrs
-            except:
-                return False
-
-        def _makedir(item, callback, parent=self.tag + "explorer", size=False):
-            file_name = os.path.basename(item)
-
-            creation_time = os.path.getctime(item)
-            creation_time = time.ctime(creation_time)
-
-            item_type = "Dir"
-
-            item_size = get_file_size(item)
-
-            kwargs_cell = {'callback': callback, 'span_columns': True, 'height': self.selec_height, 'user_data': [
-                file_name, os.path.join(os.getcwd(), file_name)]}
-            kwargs_file = {'tint_color': [255, 255, 255, 255]}
-            with dpg.table_row(parent=parent):
-                with dpg.group(horizontal=True):
-                    if item_type == "Dir":
-
-                        if _is_hidden(file_name):
-                            kwargs_file = {'tint_color': [
-                                255, 255, 255, self.image_transparency]}
-                        else:
-
-                            kwargs_file = {'tint_color': [255, 255, 255, 255]}
-
-                        dpg.add_image(self.img_mini_folder, **kwargs_file)
-                    elif item_type == "File":
-                        dpg.add_image(self.img_mini_document, **kwargs_file)
-
-                    cell_name = dpg.add_selectable(
-                        label=file_name, **kwargs_cell)
-                cell_time = dpg.add_selectable(
-                    label=creation_time, **kwargs_cell)
-                cell_type = dpg.add_selectable(label=item_type, **kwargs_cell)
-                cell_size = dpg.add_selectable(
-                    label=str(item_size), **kwargs_cell)
-
-                if self.allow_drag is True:
-                    drag_payload = dpg.add_drag_payload(
-                        parent=cell_name, payload_type=self.PAYLOAD_TYPE)
-                dpg.bind_item_theme(cell_name, selec_alignt)
-                dpg.bind_item_theme(cell_time, selec_alignt)
-                dpg.bind_item_theme(cell_type, selec_alignt)
-                dpg.bind_item_theme(cell_size, size_alignt)
-                if self.allow_drag is True:
-                    if file_name.endswith((".png", ".jpg")):
-                        dpg.add_image(self.img_big_picture,
-                                      parent=drag_payload)
-                    elif item_type == "Dir":
-                        dpg.add_image(self.img_folder, parent=drag_payload)
-                    elif item_type == "File":
-                        dpg.add_image(self.img_document, parent=drag_payload)
-
-        def _makefile(item, callback, parent=self.tag+"explorer"):
-            if self.file_filter == ".*" or item.endswith(self.file_filter):
-                file_name = os.path.basename(item)
-
-                creation_time = os.path.getctime(item)
-                creation_time = time.ctime(creation_time)
-
-                item_type = "File"
-
-                item_size = get_file_size(item)
-                kwargs_cell = {'callback': callback, 'span_columns': True, 'height': self.selec_height, 'user_data': [
-                    file_name, os.path.join(os.getcwd(), file_name)]}
-                kwargs_file = {'tint_color': [
-                    255, 255, 255, self.image_transparency]}
-                with dpg.table_row(parent=parent):
-                    with dpg.group(horizontal=True):
-
-                        if item_type == "Dir":
-                            dpg.add_image(self.img_mini_folder, **kwargs_file)
-                        elif item_type == "File":
-
-                            if _is_hidden(file_name):
-                                kwargs_file = {'tint_color': [
-                                    255, 255, 255, self.image_transparency]}
-                            else:
-                                kwargs_file = {
-                                    'tint_color': [255, 255, 255, 255]}
-
-                            if file_name.endswith((".dll", ".a", ".o", ".so", ".ko")):
-                                dpg.add_image(self.img_gears, **kwargs_file)
-
-                            elif file_name.endswith((".png", ".jpg", ".jpeg")):
-                                dpg.add_image(self.img_picture, **kwargs_file)
-
-                            elif file_name.endswith((".msi", ".exe", ".bat", ".bin", ".elf")):
-                                dpg.add_image(self.img_app, **kwargs_file)
-
-                            elif file_name.endswith(".iso"):
-                                dpg.add_image(self.img_iso, **kwargs_file)
-
-                            elif file_name.endswith((".zip", ".deb", ".rpm", ".tar.gz", ".tar", ".gz", ".lzo", ".lz4", ".7z", ".ppack")):
-                                dpg.add_image(self.img_zip, **kwargs_file)
-
-                            elif file_name.endswith((".png", ".jpg", ".jpeg")):
-                                dpg.add_image(self.img_picture, **kwargs_file)
-
-                            elif file_name.endswith((".py", ".pyo", ".pyw", ".pyi", ".pyc", ".pyz", ".pyd")):
-                                dpg.add_image(self.img_python, **kwargs_file)
-
-                            elif file_name.endswith(".c"):
-                                dpg.add_image(self.img_c, **kwargs_file)
-                            elif file_name.endswith((".js", ".json", ".cs", ".cpp", ".h", ".hpp", ".sh", ".pyl", ".rs", ".vbs", ".cmd")):
-                                dpg.add_image(self.img_script, **kwargs_file)
-
-                            elif file_name.endswith(".url"):
-                                dpg.add_image(self.img_url, **kwargs_file)
-                            elif file_name.endswith(".lnk"):
-                                dpg.add_image(self.img_link, **kwargs_file)
-
-                            elif file_name.endswith(".txt"):
-                                dpg.add_image(self.img_note, **kwargs_file)
-                            elif file_name.endswith((".mp3", ".ogg", ".wav")):
-                                dpg.add_image(
-                                    self.img_music_note, **kwargs_file)
-
-                            elif file_name.endswith((".mp4", ".mov")):
-                                dpg.add_image(self.img_video, **kwargs_file)
-
-                            elif file_name.endswith((".obj", ".fbx", ".blend")):
-                                dpg.add_image(self.img_object, **kwargs_file)
-
-                            elif file_name.endswith(".svg"):
-                                dpg.add_image(self.img_vector, **kwargs_file)
-
-                            else:
-                                dpg.add_image(
-                                    self.img_mini_document, **kwargs_file)
-
-                        cell_name = dpg.add_selectable(
-                            label=file_name, **kwargs_cell)
-                    cell_time = dpg.add_selectable(
-                        label=creation_time, **kwargs_cell)
-                    cell_type = dpg.add_selectable(
-                        label=item_type, **kwargs_cell)
-                    cell_size = dpg.add_selectable(
-                        label=str(item_size), **kwargs_cell)
-
-                    if self.allow_drag is True:
-                        drag_payload = dpg.add_drag_payload(
-                            parent=cell_name, payload_type=self.PAYLOAD_TYPE)
-                    dpg.bind_item_theme(cell_name, selec_alignt)
-                    dpg.bind_item_theme(cell_time, selec_alignt)
-                    dpg.bind_item_theme(cell_type, selec_alignt)
-                    dpg.bind_item_theme(cell_size, size_alignt)
-                    if self.allow_drag is True:
-                        if file_name.endswith((".png", ".jpg")):
-                            dpg.add_image(self.img_big_picture,
-                                          parent=drag_payload)
-                        elif item_type == "Dir":
-                            dpg.add_image(self.img_folder, parent=drag_payload)
-                        elif item_type == "File":
-                            dpg.add_image(self.img_document,
-                                          parent=drag_payload)
-
-        def _back(sender, app_data, user_data):
-            if dpg.is_key_down(dpg.mvKey_LControl) or dpg.is_key_down(dpg.mvKey_RControl):
-                dpg.set_value(sender, False)
-            else:
-                dpg.set_value(sender, False)
-                current_time = time.time()
-                if current_time - self.last_click_time < 0.5 and self.last_clicked_element == sender:
-                    dpg.set_value(self.tag+"ex_search", "")
-                    chdir("..")
-                    self.last_click_time = 0
-                self.last_click_time = current_time
-                self.last_clicked_element = sender
-
-        def filter_combo_selector(sender, app_data):
-            filter_file = dpg.get_value(sender)
-            self.file_filter = filter_file
-            cwd = os.getcwd()
-            reset_dir(default_path=cwd)
-
-        def chdir(path):
-            try:
-                os.chdir(path)
-                cwd = os.getcwd()
-                reset_dir(default_path=cwd)
-            except PermissionError as e:
-                message_box("File dialog - PerimssionError",
-                            f"Cannot open the folder because is a system folder or the access is denied\n\nMore info:\n{e}")
-            except NotADirectoryError as e:
-                message_box("File dialog - not a directory",
-                            f"The selected item is not a directory, but a file.\n\nMore info:\n{e}")
-
-        def reset_dir(file_name_filter=None, default_path=self.default_path):
-            def internal():
-                self.selected_files.clear()
-                try:
-                    dpg.configure_item(
-                        self.tag+"ex_path_input", default_value=os.getcwd())
-                    _dir = os.listdir(default_path)
-                    delete_table()
-
-                    # Separate directories and files
-                    dirs = [file for file in _dir if os.path.isdir(file)]
-                    files = [file for file in _dir if os.path.isfile(file)]
-
-                    # 'special directory' that sends back to the prevorius directory
-                    with dpg.table_row(parent=self.tag+"explorer"):
-                        dpg.add_selectable(
-                            label="..", callback=_back, span_columns=True, height=self.selec_height)
-
-                        # dir list
-                        for _dir in dirs:
-                            if not _is_hidden(_dir):
-                                if file_name_filter:
-                                    if dpg.get_value(self.tag+"ex_search") in _dir:
-                                        _makedir(_dir, open_file)
-                                else:
-                                    _makedir(_dir, open_file)
-                            elif _is_hidden(_dir) and self.show_hidden_files:
-                                if file_name_filter:
-                                    if dpg.get_value(self.tag+"ex_search") in _dir:
-                                        _makedir(_dir, open_file)
-                                else:
-                                    _makedir(_dir, open_file)
-
-                        # file list
-                        if not self.dirs_only:
-                            for file in files:
-                                if not _is_hidden(file):
-                                    if file_name_filter:
-                                        if dpg.get_value(self.tag+"ex_search") in file:
-                                            _makefile(file, open_file)
-                                    else:
-                                        _makefile(file, open_file)
-                                elif _is_hidden(file) and self.show_hidden_files:
-                                    if file_name_filter:
-                                        if dpg.get_value(self.tag+"ex_search") in file:
-                                            _makefile(file, open_file)
-                                    else:
-                                        _makefile(file, open_file)
-
-                # exceptions
-                except FileNotFoundError:
-                    print("DEV:ERROR: Invalid path : "+str(default_path))
-                except Exception as e:
-                    message_box(
-                        "File dialog - Error", f"An unknown error has occured when listing the items, More info:\n{e}")
-
-            internal()
+        
 
         """ def explorer_order(sender, user_data):
             thingforsort = dpg.get_item_children(sender, 0).index(user_data[0][0])
@@ -761,86 +767,86 @@ class FileDialog:
                 # shortcut menu
                 if (self.user_style == 0):
                     with dpg.child_window(tag=self.tag+"shortcut_menu", width=200, resizable_x=True, show=self.show_shortcuts_menu, height=-info_px):
-                        home = get_directory_path("Home")
-                        desktop = get_directory_path("Desktop")
-                        downloads = get_directory_path("Downloads")
-                        images = get_directory_path("Pictures")
-                        documents = get_directory_path("Documents")
-                        musics = get_directory_path("Music")
-                        videos = get_directory_path("Videos")
+                        home = self.get_directory_path("Home")
+                        desktop = self.get_directory_path("Desktop")
+                        downloads = self.get_directory_path("Downloads")
+                        images = self.get_directory_path("Pictures")
+                        documents = self.get_directory_path("Documents")
+                        musics = self.get_directory_path("Music")
+                        videos = self.get_directory_path("Videos")
 
                         with dpg.group(horizontal=True):
                             dpg.add_image(self.img_home)
                             dpg.add_menu_item(
-                                label="Home", callback=lambda: chdir(home))
+                                label="Home", callback=lambda: self.chdir(home))
                         with dpg.group(horizontal=True):
                             dpg.add_image(self.img_desktop)
                             dpg.add_menu_item(
-                                label="Desktop", callback=lambda: chdir(desktop))
+                                label="Desktop", callback=lambda: self.chdir(desktop))
                         with dpg.group(horizontal=True):
                             dpg.add_image(self.img_downloads)
                             dpg.add_menu_item(
-                                label="Downloads", callback=lambda: chdir(downloads))
+                                label="Downloads", callback=lambda: self.chdir(downloads))
                         with dpg.group(horizontal=True):
                             dpg.add_image(self.img_picture_folder)
                             dpg.add_menu_item(
-                                label="Images", callback=lambda: chdir(images))
+                                label="Images", callback=lambda: self.chdir(images))
                         with dpg.group(horizontal=True):
                             dpg.add_image(self.img_document_folder)
                             dpg.add_menu_item(
-                                label="Documents", callback=lambda: chdir(documents))
+                                label="Documents", callback=lambda: self.chdir(documents))
                         with dpg.group(horizontal=True):
                             dpg.add_image(self.img_music_folder)
                             dpg.add_menu_item(
-                                label="Musics", callback=lambda: chdir(musics))
+                                label="Musics", callback=lambda: self.chdir(musics))
                         with dpg.group(horizontal=True):
                             dpg.add_image(self.img_videos)
                             dpg.add_menu_item(
-                                label="Videos", callback=lambda: chdir(videos))
+                                label="Videos", callback=lambda: self.chdir(videos))
 
                         dpg.add_separator()
 
                         # i/e drives list
                         with dpg.group():
-                            drives = _get_all_drives()
+                            drives = self._get_all_drives()
                             for drive in drives:
                                 with dpg.group(horizontal=True):
                                     dpg.add_image(self.img_hard_disk)
                                     dpg.add_menu_item(
-                                        label=drive, user_data=drive, callback=open_drive)
+                                        label=drive, user_data=drive, callback=self.open_drive)
 
                 elif (self.user_style == 1):
                     with dpg.child_window(tag=self.tag+"shortcut_menu", width=40, show=self.show_shortcuts_menu, height=-info_px):
-                        home = get_directory_path("Home")
-                        desktop = get_directory_path("Desktop")
-                        downloads = get_directory_path("Downloads")
-                        images = get_directory_path("Pictures")
-                        documents = get_directory_path("Documents")
-                        musics = get_directory_path("Music")
-                        videos = get_directory_path("Videos")
+                        home = self.get_directory_path("Home")
+                        desktop = self.get_directory_path("Desktop")
+                        downloads = self.get_directory_path("Downloads")
+                        images = self.get_directory_path("Pictures")
+                        documents = self.get_directory_path("Documents")
+                        musics = self.get_directory_path("Music")
+                        videos = self.get_directory_path("Videos")
 
                         dpg.add_image_button(
-                            self.img_home, callback=lambda: chdir(home))
+                            self.img_home, callback=lambda: self.chdir(home))
                         dpg.add_image_button(
-                            self.img_desktop, callback=lambda: chdir(desktop))
+                            self.img_desktop, callback=lambda: self.chdir(desktop))
                         dpg.add_image_button(
-                            self.img_downloads, callback=lambda: chdir(downloads))
+                            self.img_downloads, callback=lambda: self.chdir(downloads))
                         dpg.add_image_button(
-                            self.img_picture_folder, callback=lambda: chdir(images))
+                            self.img_picture_folder, callback=lambda: self.chdir(images))
                         dpg.add_image_button(
-                            self.img_document_folder, callback=lambda: chdir(documents))
+                            self.img_document_folder, callback=lambda: self.chdir(documents))
                         dpg.add_image_button(
-                            self.img_music_folder, callback=lambda: chdir(musics))
+                            self.img_music_folder, callback=lambda: self.chdir(musics))
                         dpg.add_image_button(
-                            self.img_videos, callback=lambda: chdir(videos))
+                            self.img_videos, callback=lambda: self.chdir(videos))
 
                         dpg.add_separator()
 
                         with dpg.group():
-                            drives = _get_all_drives()
+                            drives = self._get_all_drives()
                             for drive in drives:
                                 dpg.add_image_button(
-                                    texture_tag=self.img_hard_disk, label=drive, user_data=drive, callback=open_drive)
+                                    texture_tag=self.img_hard_disk, label=drive, user_data=drive, callback=self.open_drive)
 
                 with dpg.child_window(height=-info_px):
                     # main explorer header
@@ -850,13 +856,13 @@ class FileDialog:
                             dpg.add_image_button(
                                 self.img_refresh, callback=lambda: reset_dir(default_path=os.getcwd()))
                             dpg.add_image_button(
-                                self.img_back, callback=lambda: chdir(self.default_path))
-                            dpg.add_input_text(hint="Path", on_enter=True, callback=on_path_enter,  default_value=os.getcwd(
+                                self.img_back, callback=lambda: self.chdir(self.default_path))
+                            dpg.add_input_text(hint="Path", on_enter=True, callback=self.on_path_enter,  default_value=os.getcwd(
                             ), width=-1, tag=self.tag+"ex_path_input")
 
                         with dpg.group(horizontal=True):
                             dpg.add_input_text(
-                                hint="Search files", callback=_search, tag=self.tag+"ex_search", width=-1)
+                                hint="Search files", callback=self._search, tag=self.tag+"ex_search", width=-1)
 
                         # main explorer table header
                         with dpg.table(
@@ -889,22 +895,22 @@ class FileDialog:
                 dpg.add_spacer(width=480)
                 dpg.add_text('File type filter')
                 dpg.add_combo(items=self.filter_list,
-                              callback=filter_combo_selector, default_value=self.file_filter, width=-1)
+                              callback=self.filter_combo_selector, default_value=self.file_filter, width=-1)
 
             with dpg.group(horizontal=True) as btn_ret_grp:
                 dpg.add_spacer(width=int(self.width*0.831))
-                dpg.add_button(label="   OK   ", tag=self.tag + "_return", callback=return_items)
+                dpg.add_button(label="   OK   ", tag=self.tag + "_return", callback=self.return_items)
                 dpg.add_button(label=" Cancel ",
                                callback=lambda: dpg.hide_item(self.tag))
 
             if self.default_path == "cwd":
-                chdir(os.getcwd())
+                self.chdir(os.getcwd())
             else:
-                chdir(self.default_path)
+                self.chdir(self.default_path)
 
     # high-level functions
     def show_file_dialog(self):
-        chdir(self.default_path)
+        self.chdir(self.default_path)
         dpg.show_item(self.tag)
 
     def change_callback(self, callback):

--- a/fdialog.py
+++ b/fdialog.py
@@ -159,7 +159,7 @@ class FileDialog:
                         self.selected_files.append(user_data[1])
                     #Check if two click within 0.5s proximity
                     if (current_time - self.last_click_time < 0.5) and (self.last_clicked_element == sender): 
-                        return_items()
+                        self.return_items()
                     else:
                         self.last_click_time = current_time
                         self.last_clicked_element = sender

--- a/fdialog.py
+++ b/fdialog.py
@@ -125,7 +125,7 @@ class FileDialog:
         else:
             self.callback(self.selected_files)
         self.selected_files.clear()
-        reset_dir(default_path=self.default_path)
+        self.reset_dir(default_path=self.default_path)
 
     def open_drive(self, sender, app_data, user_data):
         self.chdir(user_data)
@@ -396,7 +396,7 @@ class FileDialog:
         filter_file = dpg.get_value(sender)
         self.file_filter = filter_file
         cwd = os.getcwd()
-        reset_dir(default_path=cwd)
+        self.reset_dir(default_path=cwd)
 
     def chdir(self, path):
         try:
@@ -857,7 +857,7 @@ class FileDialog:
 
                         with dpg.group(horizontal=True):
                             dpg.add_image_button(
-                                self.img_refresh, callback=lambda: reset_dir(default_path=os.getcwd()))
+                                self.img_refresh, callback=lambda: self.reset_dir(default_path=os.getcwd()))
                             dpg.add_image_button(
                                 self.img_back, callback=lambda: self.chdir(self.default_path))
                             dpg.add_input_text(hint="Path", on_enter=True, callback=self.on_path_enter,  default_value=os.getcwd(

--- a/fdialog.py
+++ b/fdialog.py
@@ -429,6 +429,8 @@ class FileDialog:
                     if os.path.isdir(user_data[1]):
                         chdir(user_data[1])
                         dpg.set_value(self.tag+"ex_search", "")
+                        if (self.dirs_only == True): #If click once on directory and dirs_only == True
+                            self.selected_files = [user_data[1]]
                     elif os.path.isfile(user_data[1]):
                         if not len(self.selected_files) > 1:
                             self.selected_files.append(user_data[1])
@@ -736,7 +738,6 @@ class FileDialog:
                 except Exception as e:
                     message_box(
                         "File dialog - Error", f"An unknown error has occured when listing the items, More info:\n{e}")
-                    raise e
 
             internal()
 
@@ -892,8 +893,7 @@ class FileDialog:
 
             with dpg.group(horizontal=True) as btn_ret_grp:
                 dpg.add_spacer(width=int(self.width*0.831))
-                dpg.add_button(label="   OK   ", tag=self.tag +
-                               "_return", callback=return_items)
+                dpg.add_button(label="   OK   ", tag=self.tag + "_return", callback=return_items)
                 dpg.add_button(label=" Cancel ",
                                callback=lambda: dpg.hide_item(self.tag))
 


### PR DESCRIPTION
I have trouble creating multiple FileDialog instance due to DearPyGui error with "tag already exist" kinda error, this pull request now adds self.tag as prefix for all tagging related operations to ensure uniqueness of all inner items' tag.

Also adding feature to help select folder (That's only enabled when setting dirs_only = True), previously I can only traverse around folder and not being able to press OK to "select" a folder, as per line 432-433:
```python 
if (self.dirs_only == True): #If click once on directory and dirs_only == True
    self.selected_files = [user_data[1]]
```

The tagging system modification might be considered Breaking Change so... I don't know.... Merge it into a seperate unstable branch? I've tested it with file select, folder select, search function, all works just fine with no error/exception, so.... it's probably fine I guess?