### PR TITLE
Fixed shortcut callback issue

### DIFF
--- a/fdialog.py
+++ b/fdialog.py
@@ -791,7 +791,11 @@ class FileDialog:
                             if path is not None or os.path.exists(path):
                                 with dpg.group(horizontal=True):
                                     dpg.add_image(icon)
-                                    dpg.add_menu_item(label=label, callback=lambda p=path: self.chdir(p))
+                                    dpg.add_menu_item(
+                                        label=label, 
+                                        callback=lambda s, ad, ud: self.chdir(ud),
+                                        user_data=path
+                                    )
 
                         _add_shortcut(self.img_home, home, "Home")
                         _add_shortcut(self.img_desktop, desktop, "Desktop")


### PR DESCRIPTION
Clicking on a shortcut from the left menu ('Home', 'Desktop', etc) made my app throw an exception on os.chdir, since variable `p` was an int, not a path-like object.

In the original callback, the `path` string was set to argument `p` of the lambda as a default value, DPG overwrite this value by passing the event sender's tag (which was an int during my experimentations).

DPG's callbacks now take 3 args: `(sender: DPG tag, app_data: Any, user_data: Any)`
The menu_item's `user_data` property is set to the path's value, and then passed to the callback by DPG during an event.