### PR TITLE
Include network drives while getting disk partitions

### DIFF
--- a/fdialog.py
+++ b/fdialog.py
@@ -35,7 +35,7 @@ class FileDialog:
     """
     # low-level functions
     def _get_all_drives(self,):
-        all_drives = psutil.disk_partitions()
+        all_drives = psutil.disk_partitions(all=True)
 
         drive_list = [
             drive.mountpoint for drive in all_drives if drive.mountpoint]


### PR DESCRIPTION
psutil disk partitions only fetch physical drives in default. 
This change aims to fetch user specific drives and network drives.